### PR TITLE
Updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
-re
+regex
 flask
 flask_cors


### PR DESCRIPTION
I had an issue while installing the requirements and it said **re** doesn't exist. I instead did `pip install regex` and it worked. I don't know if this was intended or not.